### PR TITLE
Arrumar a cor das fontes

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,16 +19,6 @@ a {
   box-sizing: border-box;
 }
 
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
-  body {
-    color: white;
-    background: black;
-  }
-}
-
 input {
   outline: none;
   outline-style: none;


### PR DESCRIPTION
Resolve a issue #28
Removi a parte que muda as cores de acordo com o tema do navegador, e com isso arrumou também as cores da fonte, não vai ficar mais branco se seu tema for o escuro.